### PR TITLE
update django to 3.1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.0.*
+django>=3.1.9,<3.2
 mastodon.py
 pre-commit==1.17.*
 pytest==5.4.*


### PR DESCRIPTION
Update Django to `3.1.9` b/c [CVE-2021-31542](https://www.djangoproject.com/weblog/2021/may/04/security-releases/).